### PR TITLE
fix(packages/axios-taro-adapter/src/core/adapter): 修复mpAdapter()内引用co…

### DIFF
--- a/packages/axios-taro-adapter/src/core/adapter.ts
+++ b/packages/axios-taro-adapter/src/core/adapter.ts
@@ -16,7 +16,7 @@ export function generateMpAdapter<R extends Function>(request: R): AxiosAdapter 
       const url = buildURL(fullPath, config.params, config.paramsSerializer);
       const method = (config.method && config.method.toUpperCase()) || "GET";
       // @ts-ignore
-      const requestHeaders = AxiosHeaders.from(config.headers).normalize();
+      const requestHeaders = AxiosHeaders.from({ ...config.headers }).normalize();
       const requestData = config.data;
       const { responseType } = config;
       // console.log("序列化后的请求头:", requestHeaders);


### PR DESCRIPTION
…nfig.headers生成新headers被错误处理的问题

AxiosHeaders.from()在对入参进行处理的时候,会对不同入参类型进行不同的操作.目前直接使用外部传入的config.headers作为入参,此config.headers也是由axios生成的,因此不是一个plainObject,导致在AxiosHeaders.set内兜底到默认处理,将所有key value合并成key值,最终导致发起的请求没有任何自定义header.